### PR TITLE
Derpy duck testing improvements

### DIFF
--- a/example-2/evm/src/contracts/lendingHub/HubUtilities.sol
+++ b/example-2/evm/src/contracts/lendingHub/HubUtilities.sol
@@ -305,7 +305,9 @@ contract HubUtilities is Context, HubStructs, HubState, HubGetters, HubSetters {
 
             AssetInfo memory assetInfo = getAssetInfo(asset);
 
-            require(amount <= denormalizeAmount(getVaultAmounts(vault, asset).deposited, indices.deposited), "cannot receive more than has been deposited");
+            require(amount <= denormalizeAmount(getVaultAmounts(vault, asset).deposited, indices.deposited), "cannot receive more than has been deposited in vault");
+
+            require(amount <= denormalizeAmount(getGlobalAmounts(asset).deposited, indices.deposited), "cannot receive more than has been deposited globally");
 
             notionalReceived += amount * price * 10 ** (getMaxDecimals() - assetInfo.decimals);
         }

--- a/example-2/evm/test/Hub.t.sol
+++ b/example-2/evm/test/Hub.t.sol
@@ -80,22 +80,8 @@ contract HubTest is Test, HubStructs, HubMessages, HubGetters, HubUtilities, Tes
                 rateCoefficientA: 0,
                 reserveFactor: 0,
                  pythId: vm.envBytes32("PYTH_PRICE_FEED_AVAX_avax") 
-    }));
+        }));
         
-
-        for (uint256 i = 0; i < 3; i++) {
-            int64 startPrice = 0;
-            uint64 startConf = 0;
-            int32 startExpo = 0;
-            int64 startEmaPrice = 0;
-            uint64 startEmaConf = 0;
-            uint64 startPublishTime = 1;
-
-            getHub().setMockPythFeed(
-                getAsset(i).pythId, startPrice, startConf, startExpo, startEmaPrice, startEmaConf, startPublishTime
-            );
-        }
-
         addSpoke(
             uint16(vm.envUint("TESTING_WORMHOLE_CHAINID_AVAX")),
             vm.envAddress("TESTING_WORMHOLE_ADDRESS_AVAX"),

--- a/example-2/evm/test/Hub.t.sol
+++ b/example-2/evm/test/Hub.t.sol
@@ -49,37 +49,38 @@ contract HubTest is Test, HubStructs, HubMessages, HubGetters, HubUtilities, Tes
         
         testSetUp(vm);
 
-        addAsset(0x442F7f22b1EE2c842bEAFf52880d4573E9201158, // WBNB
-                100 * 10 ** 16,
-                110 * 10 ** 16,
-                1 * 10**18,
-                0,
-                0,
-                0,
-                 vm.envBytes32("PYTH_PRICE_FEED_AVAX_bnb")  
-        );
+        addAsset(AddAsset({
+                assetAddress: 0x442F7f22b1EE2c842bEAFf52880d4573E9201158, // WBNB
+                collateralizationRatioDeposit: 100 * 10 ** 16,
+                collateralizationRatioBorrow: 110 * 10 ** 16,
+                ratePrecision: 1 * 10**18,
+                rateIntercept: 0,
+                rateCoefficientA: 0,
+                reserveFactor: 0,
+                pythId: vm.envBytes32("PYTH_PRICE_FEED_AVAX_bnb")  
+        }));
 
-        addAsset(0x8b82A291F83ca07Af22120ABa21632088fC92931, // WETH
-                100 * 10 ** 16,
-                110 * 10 ** 16,
-                1 * 10**18,
-                0,
-                0,
-                0,
-                vm.envBytes32("PYTH_PRICE_FEED_AVAX_eth") 
-        );
+        addAsset(AddAsset({assetAddress: 0x8b82A291F83ca07Af22120ABa21632088fC92931, // WETH
+                collateralizationRatioDeposit: 100 * 10 ** 16,
+                collateralizationRatioBorrow: 110 * 10 ** 16,
+                ratePrecision: 1 * 10**18,
+                rateIntercept: 0,
+                rateCoefficientA: 0,
+                reserveFactor: 0,
+                pythId: vm.envBytes32("PYTH_PRICE_FEED_AVAX_eth") 
+    }));
 
         wrappedGasTokenAddress = address(getHubData().tokenBridgeContract.WETH());
 
-        addAsset(wrappedGasTokenAddress, // WAVAX
-                100 * 10 ** 16,
-                110 * 10 ** 16,
-                1 * 10**18,
-                0,
-                0,
-                0,
-                vm.envBytes32("PYTH_PRICE_FEED_AVAX_avax") 
-        );
+        addAsset(AddAsset({assetAddress: wrappedGasTokenAddress, // WAVAX
+                collateralizationRatioDeposit: 100 * 10 ** 16,
+                collateralizationRatioBorrow: 110 * 10 ** 16,
+                ratePrecision: 1 * 10**18,
+                rateIntercept: 0,
+                rateCoefficientA: 0,
+                reserveFactor: 0,
+                 pythId: vm.envBytes32("PYTH_PRICE_FEED_AVAX_avax") 
+    }));
         
 
         for (uint256 i = 0; i < 3; i++) {

--- a/example-2/evm/test/Hub.t.sol
+++ b/example-2/evm/test/Hub.t.sol
@@ -334,47 +334,15 @@ contract HubTest is Test, HubStructs, HubMessages, HubGetters, HubUtilities, Tes
 
 
     function testRDNative() public {
-        uint256 msgFee = getHubData().wormholeContract.messageFee();
-        Hub hub = getHub();
 
         doRegisterAsset(getAsset(2));
 
         doRegisterSpoke(0);
 
-        address user = address(this);
-
-        uint256 userInitBalance = 105 * 10 ** 18;
-
-        vm.deal(user, userInitBalance);
-   
-        VaultAmount memory globalBefore = hub.getGlobalAmounts(wrappedGasTokenAddress);
-        VaultAmount memory vaultBefore = hub.getVaultAmounts(user, wrappedGasTokenAddress);
-
-        uint256 balance_user_native_pre = address(user).balance;
-        uint256 balance_hub_native_pre = IERC20(wrappedGasTokenAddress).balanceOf(address(hub));
+        vm.deal(address(this), 105 * 10 ** 18);
 
         doDepositNative(0, 5 * (10 ** 16));
 
-        uint256 balance_user_native_post = address(user).balance;
-
-        uint256 balance_hub_native_post = IERC20(wrappedGasTokenAddress).balanceOf(address(hub));
-
-        VaultAmount memory globalAfter = hub.getGlobalAmounts(wrappedGasTokenAddress);
-        VaultAmount memory vaultAfter = hub.getVaultAmounts(user, wrappedGasTokenAddress);
-
-        require(globalBefore.deposited == 0, "Deposited not initialized to 0");
-        require(globalAfter.deposited == 5 * 10 ** 16 , "5 * 10 ** 16 wasn't deposited (globally)");
-
-        require(vaultBefore.deposited == 0, "Deposited not initialized to 0");
-        require(vaultAfter.deposited == 5 * 10 ** 16 - msgFee, "Amount minus WH msg fee wasn't deposited (in the vault)");
-
-        require(balance_user_native_pre == userInitBalance , "User gas token balance not correct initially");
-
-        require(balance_hub_native_pre == 0, "Hub gas token balance not 0 initially");
-
-        require(balance_user_native_post == userInitBalance - 5 * (10 ** 16), "User gas token balance not correct after");
-
-        require(balance_hub_native_post == 5 * (10 ** 16) - msgFee, "Hub gas token balance not correctly amount transferred minus WH msg fee after");
     }
 
     function testDNative_Fail() public {

--- a/example-2/evm/test/helpers/TestHelpers.sol
+++ b/example-2/evm/test/helpers/TestHelpers.sol
@@ -316,6 +316,19 @@ contract TestHelpers is HubStructs, HubMessages, TestStructs, TestState, TestGet
             prankAddress: address(0x0)
         }));
     }
+    function doRepay(uint256 spokeIndex, Asset memory asset, uint256 assetAmount, address prankAddress) internal {
+        doAction(ActionParameters({
+            action: Action.Repay,
+            spokeIndex: spokeIndex,
+            assetAddress: asset.assetAddress,
+            assetAmount: assetAmount,
+            expectRevert: false,
+            revertString: "",
+            paymentReversion: false,
+            prank: true,
+            prankAddress: prankAddress
+        }));
+    }
     function doRepayRevert(uint256 spokeIndex, Asset memory asset, uint256 assetAmount, address vault) internal {
         doAction(ActionParameters({
             action: Action.Repay,
@@ -446,6 +459,20 @@ contract TestHelpers is HubStructs, HubMessages, TestStructs, TestState, TestGet
             paymentReversion: false,
             prank: false,
             prankAddress: address(0x0)
+        }));
+    }
+
+    function doBorrowRevert(uint256 spokeIndex, Asset memory asset, uint256 assetAmount, string memory revertString, address prankAddress) internal {
+        doAction(ActionParameters({
+            action: Action.Borrow,
+            spokeIndex: spokeIndex,
+            assetAddress: asset.assetAddress,
+            assetAmount: assetAmount,
+            expectRevert: true,
+            revertString: revertString,
+            paymentReversion: false,
+            prank: true,
+            prankAddress: prankAddress
         }));
     }
     

--- a/example-2/evm/test/helpers/TestSetters.sol
+++ b/example-2/evm/test/helpers/TestSetters.sol
@@ -34,28 +34,21 @@ contract TestSetters is TestStructs, TestState, TestGetters {
     }
 
     function addAsset(
-        address assetAddress, 
-        uint256 collateralizationRatioDeposit, 
-        uint256 collateralizationRatioBorrow, 
-        uint64 ratePrecision,
-        uint64 rateIntercept,
-        uint64 rateCoefficientA,
-        uint256 reserveFactor, 
-        bytes32 pythId
+        AddAsset memory addAssetData
     ) internal {
-        (,bytes memory queriedDecimals) = assetAddress.staticcall(abi.encodeWithSignature("decimals()"));
+        (,bytes memory queriedDecimals) = addAssetData.assetAddress.staticcall(abi.encodeWithSignature("decimals()"));
         uint8 decimals = abi.decode(queriedDecimals, (uint8));
         Asset memory asset = Asset({
-            assetAddress: assetAddress,
-            asset: IERC20(assetAddress),
-            collateralizationRatioDeposit: collateralizationRatioDeposit,
-            collateralizationRatioBorrow: collateralizationRatioBorrow,
+            assetAddress: addAssetData.assetAddress,
+            asset: IERC20(addAssetData.assetAddress),
+            collateralizationRatioDeposit: addAssetData.collateralizationRatioDeposit,
+            collateralizationRatioBorrow: addAssetData.collateralizationRatioBorrow,
             decimals: decimals,
-            ratePrecision: ratePrecision,
-            rateIntercept: rateIntercept,
-            rateCoefficientA: rateCoefficientA,
-            reserveFactor: reserveFactor,
-            pythId: pythId
+            ratePrecision: addAssetData.ratePrecision,
+            rateIntercept: addAssetData.rateIntercept,
+            rateCoefficientA: addAssetData.rateCoefficientA,
+            reserveFactor: addAssetData.reserveFactor,
+            pythId: addAssetData.pythId
         });
         addAsset(asset);
     }

--- a/example-2/evm/test/helpers/TestSetters.sol
+++ b/example-2/evm/test/helpers/TestSetters.sol
@@ -51,6 +51,17 @@ contract TestSetters is TestStructs, TestState, TestGetters {
             pythId: addAssetData.pythId
         });
         addAsset(asset);
+
+         int64 startPrice = 0;
+            uint64 startConf = 0;
+            int32 startExpo = 0;
+            int64 startEmaPrice = 0;
+            uint64 startEmaConf = 0;
+            uint64 startPublishTime = 1;
+
+            getHub().setMockPythFeed(
+                addAssetData.pythId, startPrice, startConf, startExpo, startEmaPrice, startEmaConf, startPublishTime
+            );
     }
 
     function addSpoke(uint16 chainId, address wormholeAddress, address tokenBridgeAddress) internal {

--- a/example-2/evm/test/helpers/TestStructs.sol
+++ b/example-2/evm/test/helpers/TestStructs.sol
@@ -71,5 +71,24 @@ contract TestStructs is HubStructs {
         uint256 balanceUser;
     }
 
+    struct LiquidationDataArrays {
+            uint256[] userBalancePreRepay;
+            uint256[] hubBalancePreRepay;
+            uint256[] userBalancePostRepay;
+            uint256[] hubBalancePostRepay;
+            uint256[] userBalancePreReceipt;
+            uint256[] hubBalancePreReceipt;
+            uint256[] userBalancePostReceipt;
+            uint256[] hubBalancePostReceipt;
+            uint256[] vaultToLiquidateAmountRepayPre;
+            uint256[] vaultToLiquidateAmountReceiptPre;
+            uint256[] vaultToLiquidateAmountRepayPost;
+            uint256[] vaultToLiquidateAmountReceiptPost;
+            uint256[] globalAmountRepayPre;
+            uint256[] globalAmountReceiptPre;
+            uint256[] globalAmountRepayPost;
+            uint256[] globalAmountReceiptPost;
+    }
+
     
 }

--- a/example-2/evm/test/helpers/TestStructs.sol
+++ b/example-2/evm/test/helpers/TestStructs.sol
@@ -49,7 +49,7 @@ contract TestStructs is HubStructs {
         bytes32 emitterAddress;
     }
 
-    enum Action{Deposit, Borrow, Withdraw, Repay}
+    enum Action{Deposit, Borrow, Withdraw, Repay, DepositNative, RepayNative}
 
     struct ActionParameters {
         Action action;

--- a/example-2/evm/test/helpers/TestStructs.sol
+++ b/example-2/evm/test/helpers/TestStructs.sol
@@ -41,6 +41,18 @@ contract TestStructs is HubStructs {
         uint256 reserveFactor;
         bytes32 pythId;
     }
+
+    struct AddAsset {
+        address assetAddress;
+        uint256 collateralizationRatioDeposit;
+        uint256 collateralizationRatioBorrow;
+        uint64 ratePrecision;
+        uint64 rateIntercept;
+        uint64 rateCoefficientA;
+        uint256 reserveFactor;
+        bytes32 pythId;
+    }
+
     struct RegisterChainMessage {
         bytes32 module;
         uint8 action;

--- a/example-2/evm/test/helpers/TestUtilities.sol
+++ b/example-2/evm/test/helpers/TestUtilities.sol
@@ -215,12 +215,18 @@ contract TestUtilities is HubUtilities, TestStructs, TestState, TestGetters, Tes
         
     }
 
-    function getActionStateData(address vault, address assetAddress) internal view returns(ActionStateData memory data) {
+    function getActionStateData(address vault, address assetAddress, bool isNative) internal view returns(ActionStateData memory data) {
+        uint256 balanceUser;
+        if(isNative) {
+            balanceUser = address(vault).balance;
+        } else {
+            balanceUser = IERC20(assetAddress).balanceOf(vault);
+        }
         data = ActionStateData({
             global: getHub().getGlobalAmounts(assetAddress),
             vault: getHub().getVaultAmounts(vault, assetAddress),
             balanceHub: IERC20(assetAddress).balanceOf(address(getHub())),
-            balanceUser: IERC20(assetAddress).balanceOf(vault)
+            balanceUser: balanceUser
         });
     }
 


### PR DESCRIPTION
- Write a doLiquidate function for clarity of the Hub.t file 
- Don’t allow broken liquidate inputs (assert that array lengths are the same)
- Move nativeeth requires into the helper methods
- Change the addAsset to take in a struct 
- Move setmockpricefeed to addAsset function
- Move the liquidation checks to allowToLiquidate 
- Collect test functions (combine RDBPW and RDBPW_fail for example) 